### PR TITLE
Dockerfile for building and creating poppler tarball

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+FROM --platform=linux/amd64 heroku/heroku:20-build
+
+SHELL ["/bin/bash", "-c"]
+
+RUN wget https://poppler.freedesktop.org/poppler-21.03.0.tar.xz
+RUN tar -xf poppler-21.03.0.tar.xz
+
+RUN mkdir -p /poppler-21.03.0/build
+WORKDIR /poppler-21.03.0/build
+RUN git clone git://git.freedesktop.org/git/poppler/test
+
+RUN apt-get -y update -qq
+
+RUN apt -y install \
+    libopenjp2-7-dev
+    #libboost-dev \ # include other dependencies if slug size isn't a concern
+    #libnss3-dev \
+    #libopenjpip-dec-server \
+    #libopenjp2-tools \
+    #libgirepository1.0-dev \
+    #libgtk-3-dev \
+    #libopenjpip-server
+
+RUN cmake -DTESTDATADIR=./test -DCMAKE_INSTALL_MANDIR:PATH=/usr/local/share/man ..
+RUN make
+RUN make install
+
+RUN mkdir -p tmp/bin
+RUN mkdir -p tmp/lib/pkgconfig
+
+RUN cp /usr/local/bin/pdftoppm tmp/bin
+
+# include other utilities if slug size isn't a concern
+# RUN cp /usr/local/bin/{pdfattach,pdfdetach,pdffonts,pdfimages,pdfinfo,pdfseparate,pdftocairo,pdftohtml,pdftops,pdftotext,pdfunite} tmp/bin
+
+# -P keeps symlinks
+RUN cp -P /usr/local/lib/{libpoppler.so.108.0.0,libpoppler.so.108,libpoppler.so} tmp/lib
+
+# include other shared objects if slug size isn't a concern
+# RUN cp -P /usr/local/lib/{libpoppler-glib.so.8.19.0,libpoppler-glib.so.8,libpoppler-glib.so,libpoppler-cpp.so.0.9.0,libpoppler-cpp.so.0,libpoppler-cpp.so} tmp/lib
+
+RUN cp /usr/local/lib/pkgconfig/{poppler.pc,poppler-glib.pc,poppler-cpp.pc} tmp/lib/pkgconfig
+
+# Use metadata recommended by https://reproducible-builds.org/docs/archives/ for producing tarball with consistent checksum
+# if contents haven't changed
+RUN tar --sort=name \
+        --mtime="2023-01-15 00:00Z" \
+        --owner=0 --group=0 --numeric-owner \
+        --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
+        -czvf poppler-21.03.0.tar.gz -C tmp .

--- a/README.md
+++ b/README.md
@@ -6,4 +6,18 @@ heroku-20 needs a newer version of poppler to fix the following issue with PDFs 
 - https://bugs.launchpad.net/ubuntu/+source/poppler/+bug/1944453
 - https://stackoverflow.com/questions/66636441/pdf2image-library-failing-to-read-pdf-signed-using-docusign/74313286
 
-The only difference in this fork from [k16shikano/heroku-buildpack-poppler](https://github.com/k16shikano/heroku-buildpack-poppler) is we are using a `tar.xz` that matches the published release from the official poppler site https://poppler.freedesktop.org/poppler-21.03.0.tar.xz (md5 641a9f382c4166d5728f1f28f163de58).
+## Differences from [k16shikano/heroku-buildpack-poppler](https://github.com/k16shikano/heroku-buildpack-poppler) 
+- We are building our own binaries from scratch, using the source code `tar.xz` from the official poppler site https://poppler.freedesktop.org/poppler-21.03.0.tar.xz.
+- Due to a problem with the slug size going over the heroku limit of 500 MB, we are only packaging `pdftoppm` and its dependency so, since this is the only one used by Rails [PopplerPdfPreviewer](https://github.com/rails/rails/blob/8015c2c2cf5c8718449677570f372ceb01318a32/activestorage/lib/active_storage/previewer/poppler_pdf_previewer.rb)
+
+
+## Rebuilding from source
+
+The included `Dockerfile` installs all the necessary dependencies and builds poppler from source. Follow these steps to build the docker image and copy the tarball out.
+
+```
+docker build -t poppler-build .
+docker create --platform=linux/amd64 --name poppler-build-container poppler-build
+docker cp poppler-build-container:/poppler-21.03.0/build/poppler-21.03.0.tar.gz .
+docker rm -f poppler-build-container
+```


### PR DESCRIPTION
As mentioned in https://github.com/hackclub/heroku-buildpack-poppler/pull/3,
it turns out the published tarball from the poppler site is just the
source code. See that PR description for why we are packaging prebuilt
binaries instead of rebuilding from scratch.

This PR introduces a Dockerfile for creating a reproducible build that
is committed to the git repo. We are using tar metadata recommended by
https://reproducible-builds.org/docs/archives/ for consistent checksums.

Dependencies are based on https://www.linuxfromscratch.org/blfs/view/cvs/general/poppler.htm
and error/warning messages while running cmake. Due to an issue with
heroku slug size, we are using as few dependencies as possible and only
including the `pdftoppm` utility. See
https://github.com/hackclub/heroku-buildpack-poppler/pull/4 for more
reasoning about the files included here.
